### PR TITLE
Added Related Post Functionality

### DIFF
--- a/components/BlogEntry/BlogEntry.tsx
+++ b/components/BlogEntry/BlogEntry.tsx
@@ -2,6 +2,7 @@ import dynamic from 'next/dynamic';
 import { MDXRemote } from 'next-mdx-remote';
 import { BlogPost } from '@models/blogPost';
 import TagList from '@components/TagList';
+import RelatedPosts from '@components/RelatedPosts';
 import { formatDate } from '@lib/utilities';
 import Utterances from '@components/Utterances';
 
@@ -64,6 +65,7 @@ const BlogEntry = ({ post }: BlogEntryProps): JSX.Element => (
                 />
             </div>
 
+            <RelatedPosts posts={post.relatedPosts || []} />
             <TagList tags={post.tags} />
         </article>
         {post.commentIssueNumber !== null && (

--- a/components/RelatedPosts/RelatedPosts.module.css
+++ b/components/RelatedPosts/RelatedPosts.module.css
@@ -1,0 +1,7 @@
+.lead {
+    font-weight: bold;
+}
+
+.post {
+    margin: 8px;
+}

--- a/components/RelatedPosts/RelatedPosts.tsx
+++ b/components/RelatedPosts/RelatedPosts.tsx
@@ -1,0 +1,26 @@
+import { RelatedPost } from '@models/RelatedPost';
+
+import styles from './RelatedPosts.module.css';
+
+interface RelatedPostsProps {
+    posts: RelatedPost[];
+}
+
+const RelatedPosts = ({ posts }: RelatedPostsProps): JSX.Element => {
+    if (posts.length === 0) {
+        return null;
+    }
+
+    return (
+        <section className="related-posts">
+            <div className={styles.lead}>Related Posts</div>
+            {posts.map((p) => (
+                <div key={p.url} className={styles.post}>
+                    <a href={p.url}>{p.title}</a>
+                </div>
+            ))}
+        </section>
+    );
+};
+
+export default RelatedPosts;

--- a/components/RelatedPosts/index.tsx
+++ b/components/RelatedPosts/index.tsx
@@ -1,0 +1,2 @@
+export * from './RelatedPosts';
+export { default } from './RelatedPosts';

--- a/content/blog/2023-10-01-staying-silent-is-political-too.mdx
+++ b/content/blog/2023-10-01-staying-silent-is-political-too.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Staying Silent is Political Too'
 date: '2023-10-01'
-tags: []
+tags: ['Politics']
 commentIssueNumber: 153
 ---
 

--- a/content/blog/2023-11-21-the-media-and-protecting-democracy.mdx
+++ b/content/blog/2023-11-21-the-media-and-protecting-democracy.mdx
@@ -3,6 +3,10 @@ title: 'The Media and Protecting Democracy'
 date: '2023-11-21'
 tags: ['Politics', 'Media', 'News']
 commentIssueNumber: 171
+relatedPosts: [
+    { title: 'Staying Silent is Political Too', url: '/posts/2023/10/01/staying-silent-is-political-too'},
+    { title: "Thoughts on Trump's Failed Insurrection", url: '/posts/2021/01/07/thoughts-on-trumps-failed-insurrection'}
+]
 ---
 
 I was listening to a [Make Me Smart](https://www.marketplace.org/shows/make-me-smart/) podcast [episode](https://www.marketplace.org/shows/make-me-smart/polarization-partisanship-and-threats-to-democracy/) on my walk earlier this week and they were talking about some of the threats currently facing America, not from without, but from within. And something Kai Ryssdal said really struck home to me.

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -168,7 +168,7 @@ export const getPostPages = (): TagPage[] => {
     }));
 };
 
-export const getPostData = async (query: PostQuery) : Promise<BlogPost> => {
+export const getPostData = async (query: PostQuery): Promise<BlogPost> => {
     const {
         year,
         month,
@@ -231,10 +231,11 @@ export const getPostData = async (query: PostQuery) : Promise<BlogPost> => {
         socialImageUrl: socialImage,
         wordCount,
         readTime: readingTime,
+        relatedPosts: data.relatedPosts || [],
     };
 };
 
-export const getPaginatedPosts = (page: number, count = postsPerPage): { totalPages: number, posts: BlogPost[]} => {
+export const getPaginatedPosts = (page: number, count = postsPerPage): { totalPages: number, posts: BlogPost[] } => {
     const posts = getAllPosts();
 
     const start = (page - 1) * 10;

--- a/models/RelatedPost.ts
+++ b/models/RelatedPost.ts
@@ -1,0 +1,4 @@
+export interface RelatedPost {
+    title: string;
+    url: string;
+}

--- a/models/blogPost.ts
+++ b/models/blogPost.ts
@@ -1,4 +1,5 @@
 import { BlogTag } from '@models/BlogTag';
+import { RelatedPost } from '@models/RelatedPost';
 
 export interface BlogPost {
     id: string
@@ -15,4 +16,5 @@ export interface BlogPost {
     commentIssueNumber?: number
     wordCount?: number
     readTime?: number
+    relatedPosts?: RelatedPost[]
 }

--- a/styles/kpwags.css
+++ b/styles/kpwags.css
@@ -402,7 +402,8 @@ a img {
 }
 
 .article:hover .metadata,
-.article:hover .tags {
+.article:hover .tags,
+.article:hover .related-posts {
     border-color: var(--primary-color-1);
 }
 
@@ -417,7 +418,12 @@ a img {
 }
 
 .article .tags {
-    margin-top: 1.5rem;
+    padding: 0.5rem 1rem;
+    border-top: 1px solid var(--grey-1);
+}
+
+.article .related-posts {
+    display: block;
     padding: 0.5rem 1rem;
     border-top: 1px solid var(--grey-1);
 }


### PR DESCRIPTION
# Work Done
A new property was added to blog posts to allow for manual addition of related blog posts. These will display on the blog entry page between the blog post content and the tags. A future issue can be added (maybe?) to back-fill the related posts on older posts.

# Related Issue
- Closes #529